### PR TITLE
dependency error fix

### DIFF
--- a/NHNetworkTime/NHNetAssociation.h
+++ b/NHNetworkTime/NHNetAssociation.h
@@ -12,12 +12,9 @@
 #import <sys/time.h>
 
 
-
-#import <CocoaAsyncSocket/GCDAsyncUdpSocket.h>
-
 @protocol NHNetAssociationDelegate;
 
-@interface NHNetAssociation : NSObject <GCDAsyncUdpSocketDelegate>
+@interface NHNetAssociation : NSObject
 
 @property (readonly) NSString *server;  // server name "123.45.67.89"
 @property (readonly) BOOL active; // is this clock running yet?

--- a/NHNetworkTime/NHNetAssociation.m
+++ b/NHNetworkTime/NHNetAssociation.m
@@ -1,5 +1,6 @@
 #import "NHNetAssociation.h"
 #import <sys/time.h>
+#import "CocoaAsyncSocket/GCDAsyncUdpSocket.h"
 #import "NHNTLog.h"
 
 /*┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
@@ -66,7 +67,7 @@ double ntpDiffSeconds(NHTimeStamp *start, NHTimeStamp *stop) {
     return a + b / 4294967296.0;
 }
 
-@interface NHNetAssociation() {
+@interface NHNetAssociation() <GCDAsyncUdpSocketDelegate> {
     double fifoQueue[8];
     
     NHTimeStamp ntpClientSendTime;

--- a/NHNetworkTime/NHNetworkClock.m
+++ b/NHNetworkTime/NHNetworkClock.m
@@ -1,4 +1,5 @@
 #import <arpa/inet.h>
+#import "CocoaAsyncSocket/GCDAsyncUdpSocket.h"
 
 #import "NHNetworkClock.h"
 #import "NHNTLog.h"


### PR DESCRIPTION
There are one header file error in Cocoapods 1.0.0+ version with `use_frameworks!`, so I changed some header definition, please review.

Thanks.
