### PR TITLE
Updated CocoaAsyncSocket version in pod spec

### DIFF
--- a/NHNetworkTime.podspec
+++ b/NHNetworkTime.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '7.0'
   s.source_files = 'NHNetworkTime/*.{h,m}'
   s.framework = 'CFNetwork'
-  s.dependency 'CocoaAsyncSocket', '<=7.4.1'
+  s.dependency 'CocoaAsyncSocket', '~>7.4.1'
   s.requires_arc = true
 end


### PR DESCRIPTION
We have dependency to a more recent version of CocoaAsyncSocket (~>7.4.1) and that is conflicting with NHNetworktime as it prevents use of patches in CocoaAsyncSocket (<=7.4.1). This changes allows the use of patch releases for CocoaAsyncSocket
